### PR TITLE
Add support for array chat messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ class ChatMessage {
       this.json = { text: message }
     } else if (typeof message === 'object' && !Array.isArray(message)) {
       this.json = message
+    } else if (typeof message === 'object') {
+      this.json = { extra: message }
     } else {
       throw new Error('Expected String or Object for Message argument')
     }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -17,3 +17,7 @@ test('Parsing message that uses language file & numbers', () => {
   expect(msg.with[1].with[0].text).toBe(256)
   expect(msg.with[1].with[1].text).toBe(2)
 })
+test('Parsing a chat message which is an array', () => {
+  const msg = new ChatMessage([{ text: 'Example chat ' }, { text: 'message' }])
+  expect(msg.toString()).toBe('Example chat message')
+})


### PR DESCRIPTION
Some servers send chat messages as arrays instead of objects (for example play.originrealms.com), which is currently not supported. This PR fixes that, and also adds a test to make sure it works.