### PR TITLE
Remove resets on empty strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,7 +298,8 @@ function loader (mcVersion) {
 
       let message = Object.keys(codes).map((code) => {
         this[code] = this[code] || parent[code]
-        if (!this[code] || this[code] === 'false') return null
+        // don't add empty strings
+        if (!this[code] || this[code] === 'false' || this.text === '') return null
         if (code === 'color') {
           // return hex codes in this format
           if (this.color.startsWith('#')) return `§${this.color}`
@@ -307,7 +308,8 @@ function loader (mcVersion) {
         return codes[code]
       }).join('')
 
-      if (typeof this.text === 'string' || typeof this.text === 'number') message += `${this.text}§r`
+      // don't add empty strings
+      if ((typeof this.text === 'string' || typeof this.text === 'number') && this.text !== '') message += `${this.text}§r`
       else if (this.with) {
         const args = this.with.map(entry => entry.toMotd(lang))
         const format = lang[this.translate]

--- a/index.js
+++ b/index.js
@@ -298,7 +298,7 @@ function loader (mcVersion) {
 
       let message = Object.keys(codes).map((code) => {
         this[code] = this[code] || parent[code]
-        // don't add empty strings
+        // don't color code empty strings
         if (!this[code] || this[code] === 'false' || this.text === '') return null
         if (code === 'color') {
           // return hex codes in this format

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -31,6 +31,6 @@ it('Chat Message with a single hex color', () => {
 })
 it('Chat Message with multiple hex colors', () => {
   const msg = new ChatMessage(['', { text: 'uwu ', color: '#FF0000' }, { text: 'owo ', color: '#0000FF' }, { text: 'uwu', color: '#FF0000' }])
-  expect(msg.toMotd()).toBe('§r§#FF0000uwu §r§#0000FFowo §r§#FF0000uwu§r')
-  expect(msg.toAnsi()).toBe('\u001B[0m\u001B[38;2;255;0;0muwu \u001B[0m\u001B[38;2;0;0;255mowo \u001B[0m\u001B[38;2;255;0;0muwu\u001B[0m\u001B[0m')
+  expect(msg.toMotd()).toBe('§#FF0000uwu §r§#0000FFowo §r§#FF0000uwu§r')
+  expect(msg.toAnsi()).toBe('\u001B[38;2;255;0;0muwu \u001B[0m\u001B[38;2;0;0;255mowo \u001B[0m\u001B[38;2;255;0;0muwu\u001B[0m\u001B[0m')
 })


### PR DESCRIPTION
Remove seemingly random resets in strings.
This is definitely a breaking change. 