### PR TITLE
Better translation handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,11 +253,14 @@ function loader (registryOrVersion) {
       if (typeof this.text === 'string' || typeof this.text === 'number') message += this.text
       else if (this.with) {
         const args = this.with.map(entry => entry.toString(lang))
-        const format = lang[this.translate]
-        if (!format) message += args.join('')
-        else message += vsprintf(format, args)
+        const format = lang[this.translate] ?? this.translate
+        try {
+          message += vsprintf(format, args)
+        } catch (err) {
+
+        }
       } else if (this.translate) {
-        message += lang[this.translate]
+        message += lang[this.translate] ?? this.translate
       }
       if (this.extra) {
         message += this.extra.map((entry) => entry.toString(lang)).join('')
@@ -314,11 +317,14 @@ function loader (registryOrVersion) {
           const entryAsMotd = entry.toMotd(lang, this)
           return entryAsMotd + (entryAsMotd.includes('§') ? '§r' + message : '')
         })
-        const format = lang[this.translate]
-        if (!format) message += args.join('')
-        else message += vsprintf(format, args)
+        const format = lang[this.translate] ?? this.translate
+        try {
+          message += vsprintf(format, args)
+        } catch (err) {
+
+        }
       } else if (this.translate) {
-        message += lang[this.translate]
+        message += lang[this.translate] ?? this.translate
       }
       if (this.extra) {
         message += this.extra.map(entry => entry.toMotd(lang, this)).join('')

--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ function loader (registryOrVersion) {
         try {
           message += vsprintf(format, args)
         } catch (err) {
-
+          message += format
         }
       } else if (this.translate) {
         message += lang[this.translate] ?? this.translate
@@ -321,7 +321,7 @@ function loader (registryOrVersion) {
         try {
           message += vsprintf(format, args)
         } catch (err) {
-
+          message += format
         }
       } else if (this.translate) {
         message += lang[this.translate] ?? this.translate

--- a/index.js
+++ b/index.js
@@ -391,24 +391,8 @@ function loader (registryOrVersion) {
     // For example,
     //  printf("<%s> %s" /* fmt string */, [sender], [content])
     static fromNetwork (type, params) {
-      const msg = new ChatMessage('')
       const format = registry.chatFormattingById[type]
-      const fstr = format.formatString
-      const slices = []
-      for (let i = 0, j = 0, k = 0; i < fstr.length; i++) {
-        const c = fstr[i]
-        const cNext = fstr[i + 1]
-        if (c === '%' && cNext === 's') {
-          slices.push(fstr.slice(j, i), new ChatMessage(params[format.parameters[k++]]))
-          i++
-          j = i + 1
-          continue
-        } else if (cNext == null) {
-          slices.push(fstr.slice(j))
-        }
-      }
-      for (const slice of slices) msg.append(slice)
-      return msg
+      return new ChatMessage({ translate: format.formatString, with: format.parameters.map(p => params[p]) })
     }
   }
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -80,6 +80,11 @@ describe('Parsing chat on 1.16', function () {
     const msg = new ChatMessage({ translate: 'Hello, %s!', with: ['world'] })
     expect(msg.toString()).toBe('Hello, world!')
   })
+
+  it('Parsing a message with an invalid translation', () => {
+    const msg = new ChatMessage({ translate: 'translation.test.invalid', with: ['something'] })
+    expect(msg.toString()).toBe('hi %')
+  })
 })
 
 describe('Client-side chat formatting', function () {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -75,6 +75,11 @@ describe('Parsing chat on 1.16', function () {
     console.log(msg.toAnsi())
     expect(msg.toAnsi()).toBe('\u001b[0m\u001b[94m<\u001b[96mIM_U9G\u001b[0m\u001b[94m> \u001b[92myo sup\u001b[0m\u001b[94m\u001b[0m')
   })
+
+  it('Parsing a message with a translation key that does not exist in the language', () => {
+    const msg = new ChatMessage({ translate: 'Hello, %s!', with: ['world'] })
+    expect(msg.toString()).toBe('Hello, world!')
+  })
 })
 
 describe('Client-side chat formatting', function () {


### PR DESCRIPTION
This PR fixes the `translation.test.invalid` exploit, adds support for translation keys that do not exist in the language (such as `[%s] %s › %s`), and makes `fromNetwork` return a `translate` component.