### PR TITLE
Allow specifying which ANSI formatting codes to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Returns a text part from the message
  * `idx` - Index of the part
  * `lang` - (optional) - Set a custom lang (defaults to mcData.language)
 
-#### chat.toAnsi([lang])
+#### chat.toAnsi([lang], [codes])
 
 Converts to ansi format
  * `lang` - (optional) - Set a custom lang (defaults to mcData.language)
+ * `codes` - (optional) - Specify which ANSI formatting codes should be used for each Minecraft color code
 
 #### chat.length()
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,30 @@ module.exports = loader
 function loader (registryOrVersion) {
   const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion
   const defaultLang = registry.language
+  const defaultAnsiCodes = {
+    '§0': '\u001b[30m',
+    '§1': '\u001b[34m',
+    '§2': '\u001b[32m',
+    '§3': '\u001b[36m',
+    '§4': '\u001b[31m',
+    '§5': '\u001b[35m',
+    '§6': '\u001b[33m',
+    '§7': '\u001b[37m',
+    '§8': '\u001b[90m',
+    '§9': '\u001b[94m',
+    '§a': '\u001b[92m',
+    '§b': '\u001b[96m',
+    '§c': '\u001b[91m',
+    '§d': '\u001b[95m',
+    '§e': '\u001b[93m',
+    '§f': '\u001b[97m',
+    '§l': '\u001b[1m',
+    '§o': '\u001b[3m',
+    '§n': '\u001b[4m',
+    '§m': '\u001b[9m',
+    '§k': '\u001b[6m',
+    '§r': '\u001b[0m'
+  }
   const { MessageBuilder } = require('./MessageBuilder')(registry)
 
   /**
@@ -326,31 +350,7 @@ function loader (registryOrVersion) {
       return message
     }
 
-    toAnsi (lang = defaultLang) {
-      const codes = {
-        '§0': '\u001b[30m',
-        '§1': '\u001b[34m',
-        '§2': '\u001b[32m',
-        '§3': '\u001b[36m',
-        '§4': '\u001b[31m',
-        '§5': '\u001b[35m',
-        '§6': '\u001b[33m',
-        '§7': '\u001b[37m',
-        '§8': '\u001b[90m',
-        '§9': '\u001b[94m',
-        '§a': '\u001b[92m',
-        '§b': '\u001b[96m',
-        '§c': '\u001b[91m',
-        '§d': '\u001b[95m',
-        '§e': '\u001b[93m',
-        '§f': '\u001b[97m',
-        '§l': '\u001b[1m',
-        '§o': '\u001b[3m',
-        '§n': '\u001b[4m',
-        '§m': '\u001b[9m',
-        '§k': '\u001b[6m',
-        '§r': '\u001b[0m'
-      }
+    toAnsi (lang = defaultLang, codes = defaultAnsiCodes) {
 
       let message = this.toMotd(lang)
       for (const k in codes) {

--- a/index.js
+++ b/index.js
@@ -351,7 +351,6 @@ function loader (registryOrVersion) {
     }
 
     toAnsi (lang = defaultLang, codes = defaultAnsiCodes) {
-
       let message = this.toMotd(lang)
       for (const k in codes) {
         message = message.replace(new RegExp(k, 'g'), codes[k])


### PR DESCRIPTION
Adds an optional parameter to toAnsi that allows passing in a map of custom ANSI codes, like the more aesthetically pleasing set I came up with.