### PR TITLE
Fix potential issue in toHTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -411,8 +411,10 @@ function loader (registryOrVersion) {
         str += escapeHtml(this.text)
       } else if (this.translate) {
         const params = []
-        for (const param of this.with) {
-          params.push(param.toHTML(lang, styles, allowedFormats))
+        if (this.with) {
+          for (const param of this.with) {
+            params.push(param.toHTML(lang, styles, allowedFormats))
+          }
         }
         const format = lang[this.translate] ?? this.translate
         str += vsprintf(escapeHtml(format), params)


### PR DESCRIPTION
Chat message may have a `translate` field, but with no `with` field. Fixes toHTML code trying to iterate over possibly undefined field