### PR TITLE
fix errors if the server somehow sends an empty json chat msg

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function loader (registryOrVersion) {
      * @return {void}
      */
     parse (displayWarning = false) {
-      const json = this.json
+      const json = this.json ?? ''
       // Message scope for callback functions
       // There is EITHER, a text property or a translate property
       // If there is no translate property, there is no with property


### PR DESCRIPTION
some servers (minemen.club, specifically) have a weird thing where they will occasionally send a chat message packet that doesn't have anything in it.

just adding a ?? and setting it to an empty string if the json isn't there fixes this.