### PR TITLE
Fix unsafe object lookups

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const vsprintf = require('./format')
 const debug = require('debug')('minecraft-protocol')
 
 module.exports = loader
-const getValueSafely = (obj, key, def) => Object.keys(obj).includes(String(key)) ? obj[key] : def
+const getValueSafely = (obj, key, def) => obj.hasOwnProperty(key) ? obj[key] : def
 
 function loader (registryOrVersion) {
   const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion

--- a/index.js
+++ b/index.js
@@ -78,8 +78,8 @@ function loader (registryOrVersion) {
       } else {
         throw new Error('Expected String or Object for Message argument')
       }
-      this.parse(displayWarning)
       this.warn = displayWarning ? console.warn : debug
+      this.parse(displayWarning)
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const vsprintf = require('./format')
 const debug = require('debug')('minecraft-protocol')
 
 module.exports = loader
-const getValueSafely = (obj, key, def) => obj.hasOwnProperty(key) ? obj[key] : def
+const getValueSafely = (obj, key, def) => Object.hasOwn(obj, key) ? obj[key] : def
 
 function loader (registryOrVersion) {
   const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const vsprintf = require('./format')
 const debug = require('debug')('minecraft-protocol')
 
 module.exports = loader
-const getValueSafely = (obj, key, def) => Object.keys(obj).includes(key) ? obj[key] : def
+const getValueSafely = (obj, key, def) => Object.keys(obj).includes(String(key)) ? obj[key] : def
 
 function loader (registryOrVersion) {
   const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion
@@ -443,7 +443,7 @@ function loader (registryOrVersion) {
     //  printf("<%s> %s" /* fmt string */, [sender], [content])
     static fromNetwork (type, params) {
       const format = getValueSafely(registry.chatFormattingById, type)
-      if (!format) throw new Error('unknown chat format code: ' + type) // The server may be attempting to send a chat message before sending a login codec, which is not allowed
+      if (format == null) throw new Error('unknown chat format code: ' + type) // The server may be attempting to send a chat message before sending a login codec, which is not allowed
       return new ChatMessage({ translate: format.formatString, with: format.parameters.map(p => getValueSafely(params, p, '')) })
     }
   }


### PR DESCRIPTION
Fix https://github.com/PrismarineJS/node-minecraft-protocol/issues/1252 by preventing arbitrary object lookups triggered from network packets that may return Object prototype functions and props (like `constructor`, and other underscore props)