### PR TITLE
1.20.3 nbt chat handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,11 @@ runs `JSON.stringify()` on `this`
 
 #### static MessageBuilder.fromString(str, {colorSeparator = '&'}) : MessageBuilder
 convert string with color codes like `&4Hello&cWorld` to a `MessageBuilder` object
+
+### processNbtMessage
+
+This method is internally called by fromNotch.
+
+mcpc 1.20.3 uses NBT instead of JSON in some places to store chat, so the schema is a bit different.
+`processNbtMessage` normalizes the JS object obtained from nbt derealization to the old JSON schema,
+so it can be used to instantiate a ChatMessage.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-declare const loader: (registryOrVersion: string) => typeof ChatMessage
-
 declare class ChatMessage {
   // for export
   static MessageBuilder: typeof MessageBuilder
@@ -201,11 +199,6 @@ declare class MessageBuilder {
   static fromNetwork (messageType: number, parameters: Record<string, Object>): MessageBuilder
 }
 
-export default loader
-export {
-  ChatMessage
-}
-
 type Language = { [key: string]: string }
 
 type Color =
@@ -232,3 +225,14 @@ type Color =
   | "italic"
   | "reset"
 type DefaultFormats = 'color' | 'bold' | 'strikethrough' | 'underlined' | 'italic'
+
+// mcpc 1.20.3 uses NBT instead of JSON in some places to store chat, so the schema is a bit different
+// processNbtMessage normalizes the JS object obtained from nbt derealization to the old JSON schema
+function processNbtMessage(parsedNbtObject)
+
+declare const loader: (registryOrVersion: string) => typeof ChatMessage
+export default loader
+export {
+  ChatMessage,
+  processNbtMessage
+}

--- a/index.js
+++ b/index.js
@@ -429,7 +429,7 @@ function loader (registryOrVersion) {
     static fromNotch (msg) {
       if (registry.supportFeature('chatPacketsUseNbtComponents') && msg.type) {
         const json = processNbtMessage(msg)
-        return new ChatMessage(JSON.parse(json))
+        return new ChatMessage(json ? JSON.parse(json) : '')
       } else {
         try {
           return new ChatMessage(JSON.parse(msg))
@@ -465,6 +465,7 @@ function uuidFromIntArray (arr) {
   return buf.toString('hex')
 }
 function processNbtMessage (msg) {
+  if (!msg) return null
   const simplified = nbt.simplify(msg)
   const json = JSON.stringify(simplified, (key, val) => {
     if (key === 'id' && Array.isArray(val)) return uuidFromIntArray(val)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const mojangson = require('mojangson')
 const vsprintf = require('./format')
 const debug = require('debug')('minecraft-protocol')
+const nbt = require('prismarine-nbt')
 const getValueSafely = (obj, key, def) => Object.hasOwn(obj, key) ? obj[key] : def
 
 function loader (registryOrVersion) {
@@ -427,7 +428,7 @@ function loader (registryOrVersion) {
 
     static fromNotch (msg) {
       if (registry.supportFeature('chatPacketsUseNbtComponents') && msg.type) {
-        const msg = processNbtMessage(msg)
+        const json = processNbtMessage(msg)
         return new ChatMessage(JSON.parse(json))
       } else {
         try {
@@ -469,6 +470,7 @@ function processNbtMessage (msg) {
     if (key === 'id' && Array.isArray(val)) return uuidFromIntArray(val)
     return val
   })
+  return json
 }
 module.exports.processNbtMessage = processNbtMessage
 

--- a/index.js
+++ b/index.js
@@ -465,7 +465,7 @@ function uuidFromIntArray (arr) {
   return buf.toString('hex')
 }
 function processNbtMessage (msg) {
-  if (!msg) return null
+  if (!msg || msg.type === 'end') return null
   const simplified = nbt.simplify(msg)
   const json = JSON.stringify(simplified, (key, val) => {
     if (key === 'id' && Array.isArray(val)) return uuidFromIntArray(val)

--- a/index.js
+++ b/index.js
@@ -429,11 +429,13 @@ function loader (registryOrVersion) {
       if (registry.supportFeature('chatPacketsUseNbtComponents') && msg.type) {
         const msg = processNbtMessage(msg)
         return new ChatMessage(JSON.parse(json))
-      } else try {
-        return new ChatMessage(JSON.parse(msg))
-      } catch (e) {
-        return new ChatMessage(msg)
-      }      
+      } else {
+        try {
+          return new ChatMessage(JSON.parse(msg))
+        } catch (e) {
+          return new ChatMessage(msg)
+        }
+      }
     }
 
     // 1.19 applies chat formatting on the client side. A format string is provided like in C printf

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "expect": "^29.1.0",
     "mocha": "^10.0.0",
     "prismarine-chat": "file:.",
-    "standard": "^17.0.0"
+    "standard": "^17.0.0",
+    "prismarine-item": "^1.10.0"
   },
   "dependencies": {
     "mojangson": "^2.0.1",
-    "prismarine-item": "^1.10.0",
     "prismarine-nbt": "^2.0.0",
     "prismarine-registry": "^1.4.0"
   }


### PR DESCRIPTION
Expose a `processNbtMessage` method for 1.20.3 chat handling, called in fromNotch
```
// mcpc 1.20.3 uses NBT instead of JSON in some places to store chat, so the schema is a bit different over network
// processNbtMessage normalizes the JS object obtained from nbt derealization to the old JSON schema
```