### PR TITLE
Handle big and deep messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -417,7 +417,7 @@ function loader (registryOrVersion) {
         const params = []
         if (this.with) {
           for (const param of this.with) {
-            params.push(param.toHTML(lang, styles, allowedFormats, _depth))
+            params.push(param.toHTML(lang, styles, allowedFormats, _depth + 1))
           }
         }
         const format = getValueSafely(lang, this.translate, this.translate)
@@ -425,7 +425,7 @@ function loader (registryOrVersion) {
       }
 
       if (this.extra) {
-        str += this.extra.map(entry => entry.toHTML(lang, styles, allowedFormats, _depth)).join('')
+        str += this.extra.map(entry => entry.toHTML(lang, styles, allowedFormats, _depth + 1)).join('')
       }
       str += '</span>'
       // It's not safe to truncate HTML so just return unformatted text

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -126,3 +126,31 @@ describe('Client-side chat formatting', function () {
     assert.strictEqual(msg.toString(), '💬 [Admin] Player » hello world ! ⏎')
   })
 })
+
+describe('Big message parsing', function () {
+  const ChatMessage = require('prismarine-chat')('1.16')
+  const translate = '%1$s'.repeat(32)
+  const format = {
+    text: 'a',
+    color: 'dark_red',
+    bold: true,
+    italic: true,
+    strikethrough: true,
+    underlined: true,
+    obfuscated: true
+  }
+  it('handles big messages', function () {
+    const _with = [format]
+    const big = { translate, with: _with }
+    for (let i = 0; i < 7; i++) _with[0] = structuredClone(big)
+    const message = new ChatMessage(big)
+    assert.strictEqual(message.toString().length, 4096)
+  })
+  it('handles too deep messages', function () {
+    const _with = [format]
+    const big = { translate, with: _with }
+    for (let i = 0; i < 10; i++) _with[0] = structuredClone(big)
+    const message = new ChatMessage(big)
+    assert.strictEqual(message.toString().length, 0)
+  })
+})


### PR DESCRIPTION
Limit allowed depth of messages to 8 and limit length of (formatted) messages to first 4096 characters (normal minecraft client chat limit is 512 chars).

Fix #106 